### PR TITLE
Constrói a imagem docker da app caso os testes passem com êxito.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,12 @@ before_install:
 script:
   - docker-compose -f docker-compose-build.yml run --rm django python manage.py test --failfast
 
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
+    docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
+    docker build -t $(TRAVIS_REPO_SLUG):$(TRAVIS_COMMIT::8) .;
+    docker tag $(TRAVIS_REPO_SLUG):$(TRAVIS_COMMIT::8) $(TRAVIS_REPO_SLUG):latest;
+    docker tag $(TRAVIS_REPO_SLUG):$(TRAVIS_COMMIT::8) $(TRAVIS_REPO_SLUG):travis-$(TRAVIS_BUILD_NUMBER);
+    docker push $(TRAVIS_REPO_SLUG);
+    fi
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+compose/django/Dockerfile


### PR DESCRIPTION
Utiliza a diretiva ``after_success`` do Travis-CI para construir a
imagem caso os testes passem com êxito após a integração no branch
master.

Para que a imagem seja submetida ao registro de imagens
(hub.docker.com), as variáveis de ambiente devem ser definidas:
``DOCKER_USER`` e ``DOCKER_PASS``.

Foi criado o link simbólico ``Dockerfile`` para ``compose/django/Dockerfile`` para facilitar a construção da imagem de produção pelo Travis-CI.