### PR TITLE
fix #79 configura nginx para aceitar uploads de arquivos grandes

### DIFF
--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -34,10 +34,13 @@ http {
         listen 80;
         charset     utf-8;
 
-        location / {
-        # Max size of package
-        client_max_body_size       1000m;
-        client_body_buffer_size     128k;
+        location /frontdesk/deposits/ {
+            # Max size of package
+            client_max_body_size       1000m;
+            client_body_buffer_size     128k;
+
+           try_files $uri @proxy_to_app;
+        }
 
         location / {
             # checks for static file, if not found proxy to app


### PR DESCRIPTION
Ajusta a configuração nginx para aceitar arquivos maiores apenas para o endpoint específico de depósitos.