### PR TITLE
Define o uso do módulo *config.settings.test* durante os testes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - docker-compose -f docker-compose-build.yml ps
 
 script:
-  - docker-compose -f docker-compose-build.yml run --rm django python manage.py test --failfast
+  - docker-compose -f docker-compose-build.yml run --rm -e DJANGO_SETTINGS_MODULE='config.settings.test' django python manage.py test --failfast
 
 after_success:
   - git clean -fdx

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 start:
 	@docker-compose -f docker-compose-dev.yml up -d
 
@@ -6,7 +5,9 @@ stop:
 	@docker-compose -f docker-compose-dev.yml stop
 
 test:
-	@docker-compose -f docker-compose-dev.yml run --rm django python manage.py test --failfast
+	@docker-compose -f docker-compose-dev.yml run --rm \
+	-e DJANGO_SETTINGS_MODULE='config.settings.test' django \
+	python manage.py test --failfast
 
 status:
 	@docker-compose -f docker-compose-dev.yml ps
@@ -15,7 +16,8 @@ clean:
 	@docker-compose -f docker-compose-dev.yml rm
 
 shell:
-	@docker-compose -f docker-compose-dev.yml run --rm django python manage.py shell_plus
+	@docker-compose -f docker-compose-dev.yml run --rm django \
+	python manage.py shell_plus
 
 build:
 	@docker-compose -f docker-compose-dev.yml build


### PR DESCRIPTION
Fixes #91

O módulo *config.settings.test* passou a ser explicitado por meio da
variável de ambiente *DJANGO_SETTINGS_MODULE* para a execução da tarefa
*test*, do Makefile, e também para a execução do script pelo Travis-CI.