### PR TITLE
Define *gevent* como o tipo de worker do Gunicorn.

### DIFF
--- a/compose/django/gunicorn.sh
+++ b/compose/django/gunicorn.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 python /app/manage.py migrate #todo: reavaliar a execução automática
 python /app/manage.py collectstatic --noinput
-/usr/local/bin/gunicorn config.wsgi -w 4 -b 0.0.0.0:5000 --chdir=/app --log-level=$DJANGO_LOG_LEVEL --timeout=0
+/usr/local/bin/gunicorn config.wsgi \
+  -k gevent \
+  -w $(python -c "import multiprocessing; print(2 * multiprocessing.cpu_count())") \
+  -b 0.0.0.0:5000 \
+  --chdir=/app \
+  --log-level=$DJANGO_LOG_LEVEL \
+  --timeout=0
+


### PR DESCRIPTION
Fixes #94 

* O número de workers será definido dinamicamente segundo a fórmula ``2 * total de cpus``
* Quebras de linha para facilitar a visualização (de usuários de VIM rs)

As consultas ao banco de dados serão sincronizadas por conta de [detalhes do driver _psycopg2_](http://initd.org/psycopg/docs/advanced.html#support-for-coroutine-librarieshttp://initd.org/psycopg/docs/advanced.html#support-for-coroutine-libraries). 

