### PR TITLE
Corrige bug na definição do release da app com base no HEAD do git.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_success:
   - git clean -fdx
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
-    docker build -t $TRAVIS_REPO_SLUG:$COMMIT .;
+    docker build -t $TRAVIS_REPO_SLUG:$COMMIT --build-arg VCS_REF=$COMMIT .;
     docker tag $TRAVIS_REPO_SLUG:$COMMIT $TRAVIS_REPO_SLUG:latest;
     docker tag $TRAVIS_REPO_SLUG:$COMMIT $TRAVIS_REPO_SLUG:travis-$TRAVIS_BUILD_NUMBER;
     docker push $TRAVIS_REPO_SLUG;

--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 MAINTAINER SciELO <scielo-dev@googlegroups.com>
 
+ARG VCS_REF
+ENV VCS_REF ${VCS_REF}
+
 RUN apt-get update \
     && apt-get install -qqy apt-utils \
     && apt-get install -qqy libxml2-utils

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -142,11 +142,10 @@ ADMIN_URL = env('DJANGO_ADMIN_URL')
 # Integration with Sentry's real time error tracking.
 _SENTRY_DSN = env('INBOX_SENTRY_DSN', default=None)
 if _SENTRY_DSN is not None:
-    import raven
     INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
     RAVEN_CONFIG = {
         'dsn': _SENTRY_DSN,
-        # Automatically configure the release based on the git info.
-        'release': raven.fetch_git_sha(str(ROOT_DIR)),
+        # Configure the release based on the git info from VCS_REF env var.
+        'release': env('VCS_REF', default='Undefined'),
     }
 


### PR DESCRIPTION
Fixes #98

Troca a abordagem utilizada na obtenção do hash referente ao HEAD do
repositório git. O valor é utilizado na integração com o Sentry --
monitor de erros -- para indicar qual o release que apresentou
determinado erro. Anteriormente o valor era obtido por meio da execução
da função ``raven.fetch_git_sha()`` no módulo de configurações do
Django. A nova abordagem se baseia em um argumento passado durante a
construção da imagem, que é definido como variável de ambiente e
acessado pela app.