### PR TITLE
Corrige bug que impede a conexão com o ClamAV.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -247,5 +247,5 @@ ADMIN_URL = r'^admin/'
 # Your common stuff: Below this line define 3rd party library settings
 # ClamAV Antivirus
 CLAMAV_HOST = env('CLAMAV_HOST', default='clamav')
-CLAMAV_PORT = env('CLAMAV_PORT', default=3310)
+CLAMAV_PORT = env.int('CLAMAV_PORT', default=3310)
 

--- a/frontdesk/utils.py
+++ b/frontdesk/utils.py
@@ -83,7 +83,7 @@ def scan_file_for_viruses(file):
     """
     try:
         antivirus = pyclamd.ClamdNetworkSocket(
-                host=CLAMAV_HOST, port=CLAMAV_PORT)
+                host=CLAMAV_HOST, port=int(CLAMAV_PORT))
     except pyclamd.ConnectionError as exc:
         raise AntivirusConnectionError() from exc
 


### PR DESCRIPTION
Fixes #102

O código garante que o valor referente a porta de escuta do servidor do
ClamAV seja do tipo ``int``. Essa garantia está se baseia em 2 pontos:

* na obtenção do valor atribuído a variável de ambiente ``CLAMAV_PORT``;
* na função ``utils.scan_file_for_viruses``, que acessa o valor por meio
de uma variável global do módulo.