### PR TITLE
Resolve bug que causava conflito na definição de variáveis de ambiente.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -246,6 +246,6 @@ ADMIN_URL = r'^admin/'
 
 # Your common stuff: Below this line define 3rd party library settings
 # ClamAV Antivirus
-CLAMAV_HOST = env('CLAMAV_HOST', default='clamav')
-CLAMAV_PORT = env.int('CLAMAV_PORT', default=3310)
+CLAMAV_HOST = env('INBOX_CLAMAV_HOST', default='clamav')
+CLAMAV_PORT = env.int('INBOX_CLAMAV_PORT', default=3310)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
   django:
     image: scieloorg/inbox
     environment:
-      - CLAMAV_HOST=your-value-here
-      - CLAMAV_PORT=your-value-here
+      - INBOX_CLAMAV_HOST=your-value-here
+      - INBOX_CLAMAV_PORT=your-value-here
       - DJANGO_ACCOUNT_ALLOW_REGISTRATION=your-value-here
       - DJANGO_ADMIN_URL=your-value-here
       - DJANGO_ALLOWED_HOSTS=your-value-here
@@ -73,8 +73,8 @@ services:
   celeryworker:
     image: scieloorg/inbox
     environment:
-      - CLAMAV_HOST:your-value-here
-      - CLAMAV_PORT=your-value-here
+      - INBOX_CLAMAV_HOST:your-value-here
+      - INBOX_CLAMAV_PORT=your-value-here
       - DJANGO_ACCOUNT_ALLOW_REGISTRATION=your-value-here
       - DJANGO_ADMIN_URL=your-value-here
       - DJANGO_ALLOWED_HOSTS=your-value-here
@@ -100,8 +100,8 @@ services:
   celerybeat:
     image: scieloorg/inbox
     environment:
-      - CLAMAV_HOST:your-value-here
-      - CLAMAV_PORT=your-value-here
+      - INBOX_CLAMAV_HOST:your-value-here
+      - INBOX_CLAMAV_PORT=your-value-here
       - DJANGO_ACCOUNT_ALLOW_REGISTRATION=your-value-here
       - DJANGO_ADMIN_URL=your-value-here
       - DJANGO_ALLOWED_HOSTS=your-value-here


### PR DESCRIPTION
Fixes #107 (Veja a descrição do ticket para mais detalhes).

As variáveis de ambiente foram prefixadas com ``INBOX_``, para evitar o
conflito de nomes com as variáveis de ambiente definidas pelo ambiente
de execução do Docker.