### PR TITLE
Encerra as pseudo-constantes no contexto de classes.

### DIFF
--- a/frontdesk/models.py
+++ b/frontdesk/models.py
@@ -14,13 +14,16 @@ from packtools import utils as packtools_utils
 from . import signals
 
 
-PACKAGE_VIRUSSCAN_STATUS_QUEUED = 'queued'
-PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED = 'undetermined'
-PACKAGE_VIRUSSCAN_STATUS_INFECTED = 'infected'
-PACKAGE_VIRUSSCAN_STATUS_UNINFECTED = 'uninfected'
+class VirusScanStatus:
+    QUEUED = 'queued'
+    UNDETERMINED = 'undetermined'
+    INFECTED = 'infected'
+    UNINFECTED = 'uninfected'
 
-XMLMEMBER_SPS_STATUS_VALID = 'valid'
-XMLMEMBER_SPS_STATUS_INVALID = 'invalid'
+
+class SPSStatus:
+    VALID = 'valid'
+    INVALID = 'invalid'
 
 
 class Deposit(TimeStampedModel):
@@ -55,12 +58,12 @@ class Package(TimeStampedModel):
     status na verificação de vírus. São os atributos cujo identificador
     começa com ``virus_scan_``. Os status possíveis são representados pelas
     variáveis:
-      - models.PACKAGE_VIRUSSCAN_STATUS_QUEUED (verificação ainda pendente),
-      - models.PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED (quando não foi possível
+      - models.VirusScanStatus.QUEUED (verificação ainda pendente),
+      - models.VirusScanStatus.UNDETERMINED (quando não foi possível
         verificar o pacote, por exemplo por exceder o tamanho máximo aceito
         pelo antivirus),
-      - models.PACKAGE_VIRUSSCAN_STATUS_INFECTED (o pacote está infectado),
-      - models.PACKAGE_VIRUSSCAN_STATUS_UNINFECTED (o pacote não está infectado).
+      - models.VirusScanStatus.INFECTED (o pacote está infectado),
+      - models.VirusScanStatus.UNINFECTED (o pacote não está infectado).
 
     A superclasse ``TimeStampedModel`` provê os atributos ``created`` e
     ``modified``, contendo a data e hora de criação e de modificação da
@@ -75,15 +78,15 @@ class Package(TimeStampedModel):
     md5_sum = models.CharField(max_length=32)  # 32 dígitos hexadecimais
 
     VIRUS_SCAN_STATUS = Choices(
-            PACKAGE_VIRUSSCAN_STATUS_QUEUED,
-            PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED,
-            PACKAGE_VIRUSSCAN_STATUS_INFECTED,
-            PACKAGE_VIRUSSCAN_STATUS_UNINFECTED)
+            VirusScanStatus.QUEUED,
+            VirusScanStatus.UNDETERMINED,
+            VirusScanStatus.INFECTED,
+            VirusScanStatus.UNINFECTED)
     virus_scan_status = StatusField(choices_name='VIRUS_SCAN_STATUS')
     virus_scan_status_changed = MonitorField(monitor='virus_scan_status',
-            when=[PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED,
-                  PACKAGE_VIRUSSCAN_STATUS_INFECTED,
-                  PACKAGE_VIRUSSCAN_STATUS_UNINFECTED])
+            when=[VirusScanStatus.UNDETERMINED,
+                  VirusScanStatus.INFECTED,
+                  VirusScanStatus.UNINFECTED])
     virus_scan_details = models.CharField(max_length=2048, default='')
 
     def xmls(self):
@@ -147,7 +150,7 @@ class PackageMember(models.Model):
         except XMLMemberControlAttrs.DoesNotExist:
             return (None, {})
         else:
-            if XMLMEMBER_SPS_STATUS_VALID == xmlattrs.sps_check_status:
+            if SPSStatus.VALID == xmlattrs.sps_check_status:
                 is_valid = True
             else:
                 is_valid = False
@@ -177,8 +180,8 @@ class XMLMemberControlAttrs(models.Model):
             related_name='xml_control_attrs')
 
     SPS_CHECK_STATUS = Choices(
-            XMLMEMBER_SPS_STATUS_VALID,
-            XMLMEMBER_SPS_STATUS_INVALID)
+            SPSStatus.VALID,
+            SPSStatus.INVALID)
     sps_check_status = StatusField(choices_name='SPS_CHECK_STATUS')
     sps_check_status_changed = MonitorField(monitor='sps_check_status')
     sps_check_details = JSONField()

--- a/frontdesk/tasks.py
+++ b/frontdesk/tasks.py
@@ -2,6 +2,12 @@ import logging
 
 from django.db import transaction
 
+import packtools
+from packtools import (
+        stylechecker,
+        utils as packtools_utils,
+)
+
 from inbox.taskapp.celery import app
 from . import (
         models,
@@ -9,17 +15,6 @@ from . import (
         signals,
 )
 
-import packtools
-from packtools import (
-        stylechecker,
-        utils as packtools_utils,
-)
-
-from . import (
-        models,
-        utils,
-        signals,
-)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,13 +54,13 @@ def scan_package_for_viruses(self, package_id):
     except utils.AntivirusConnectionError as exc:
         self.retry(exc)
     except utils.AntivirusBufferTooLongError as exc:
-        scan_status = models.PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED
+        scan_status = models.VirusScanStatus.UNDETERMINED
         scan_details = str(exc)
     else:
         if is_infected:
-            scan_status = models.PACKAGE_VIRUSSCAN_STATUS_INFECTED
+            scan_status = models.VirusScanStatus.INFECTED
         else:
-            scan_status = models.PACKAGE_VIRUSSCAN_STATUS_UNINFECTED
+            scan_status = models.VirusScanStatus.UNINFECTED
 
         scan_details = str(details)  # representação textual de uma tupla
 
@@ -119,9 +114,9 @@ def validate_package_member(member_id):
             summary = stylechecker.summarize(validator)
 
     if summary['is_valid']:
-        check_status = models.XMLMEMBER_SPS_STATUS_VALID
+        check_status = models.SPSStatus.VALID
     else:
-        check_status = models.XMLMEMBER_SPS_STATUS_INVALID
+        check_status = models.SPSStatus.INVALID
 
     models.XMLMemberControlAttrs.objects.create(
             member=member,

--- a/frontdesk/templatetags/frontdesk_extras.py
+++ b/frontdesk/templatetags/frontdesk_extras.py
@@ -1,12 +1,7 @@
 from django import template
 from django.template.defaultfilters import stringfilter
 
-from frontdesk.models import (
-        PACKAGE_VIRUSSCAN_STATUS_INFECTED,
-        PACKAGE_VIRUSSCAN_STATUS_UNINFECTED,
-        PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED,
-        PACKAGE_VIRUSSCAN_STATUS_QUEUED,
-)
+from .. import models
 
 
 register = template.Library()
@@ -35,10 +30,10 @@ BOX_COLORS = {
 
 
 ACCEPTED_VIRUS_SCAN_STATUSES = [
-    PACKAGE_VIRUSSCAN_STATUS_UNINFECTED,
-    PACKAGE_VIRUSSCAN_STATUS_QUEUED,
-    PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED,
-    PACKAGE_VIRUSSCAN_STATUS_INFECTED,
+    models.VirusScanStatus.UNINFECTED,
+    models.VirusScanStatus.QUEUED,
+    models.VirusScanStatus.UNDETERMINED,
+    models.VirusScanStatus.INFECTED,
 ]
 
 
@@ -109,7 +104,7 @@ def should_warn_before_downloading(virusscan_status):
     que ele não está infectado.
 
     Quando o status for igual a constante do
-    models.PACKAGE_VIRUSSCAN_STATUS_UNINFECTED ele retornará falso.
+    models.VirusScanStatus.UNINFECTED ele retornará falso.
     Não necessitando informar o usuário sobre a possibilidade de vírus no pacote.
 
     Este filtro foi projetado para auxiliar a confecção de templates,
@@ -125,7 +120,7 @@ def should_warn_before_downloading(virusscan_status):
     if virusscan_status not in ACCEPTED_VIRUS_SCAN_STATUSES:
         raise ValueError('Status not supported')
 
-    if virusscan_status == PACKAGE_VIRUSSCAN_STATUS_UNINFECTED:
+    if virusscan_status == models.VirusScanStatus.UNINFECTED:
         return False
 
     return True

--- a/frontdesk/tests/test_tasks.py
+++ b/frontdesk/tests/test_tasks.py
@@ -29,7 +29,7 @@ class ValidatePackageMemberTests(TestCase):
         _ = tasks.validate_package_member(member.pk)
 
         self.assertTrue(member.xml_control_attrs.sps_check_status in
-                [models.XMLMEMBER_SPS_STATUS_VALID, models.XMLMEMBER_SPS_STATUS_INVALID])
+                [models.SPSStatus.VALID, models.SPSStatus.INVALID])
         self.assertIsInstance(member.xml_control_attrs.sps_check_details,
                 dict)
 

--- a/frontdesk/tests/test_templatetags.py
+++ b/frontdesk/tests/test_templatetags.py
@@ -2,13 +2,7 @@ from unittest import TestCase
 
 from django.template import Template, Context
 
-from frontdesk.models import (
-        Package,
-        PACKAGE_VIRUSSCAN_STATUS_QUEUED,
-        PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED,
-        PACKAGE_VIRUSSCAN_STATUS_INFECTED,
-        PACKAGE_VIRUSSCAN_STATUS_UNINFECTED,
-)
+from frontdesk import models
 from frontdesk.templatetags import frontdesk_extras as tags
 
 
@@ -261,24 +255,25 @@ class TemplatetagsTest(TestCase):
 
     def test_should_warn_before_downloading_queued(self):
         result = tags.should_warn_before_downloading(
-                PACKAGE_VIRUSSCAN_STATUS_QUEUED)
+                models.VirusScanStatus.QUEUED)
         self.assertTrue(result)
 
     def test_should_warn_before_downloading_undetermined(self):
         result = tags.should_warn_before_downloading(
-                PACKAGE_VIRUSSCAN_STATUS_UNDETERMINED)
+                models.VirusScanStatus.UNDETERMINED)
         self.assertTrue(result)
 
     def test_should_warn_before_downloading_infected(self):
         result = tags.should_warn_before_downloading(
-                PACKAGE_VIRUSSCAN_STATUS_INFECTED)
+                models.VirusScanStatus.INFECTED)
         self.assertTrue(result)
 
     def test_should_warn_before_downloading_uninfected(self):
         result = tags.should_warn_before_downloading(
-                PACKAGE_VIRUSSCAN_STATUS_UNINFECTED)
+                models.VirusScanStatus.UNINFECTED)
         self.assertFalse(result)
 
     def test_should_warn_before_downloading_unknown_status(self):
         self.assertRaises(ValueError,
-                          lambda: tags.should_warn_before_downloading(Package()))
+                          lambda: tags.should_warn_before_downloading(
+                              models.Package()))


### PR DESCRIPTION
Essa modificação não apresenta impacto em funcionalidade, mas aumenta a
legibilidade dos códigos ao agrupar as pseudo-constantes de acordo com
suas funções.